### PR TITLE
chore: add npm bugs metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,9 @@
 		"url": "git+https://github.com/kysely-org/kysely-neon.git"
 	},
 	"homepage": "https://kysely.dev",
+	"bugs": {
+		"url": "https://github.com/kysely-org/kysely-neon/issues"
+	},
 	"author": "Severin Ibarluzea",
 	"contributors": [
 		"Igal Klebanov <igalklebanov@gmail.com>"


### PR DESCRIPTION
## Summary

Adds the missing npm `bugs.url` metadata to `kysely-neon`, pointing to this repository's issue tracker.

This is metadata-only; runtime code, dependencies, exports, and build behavior are unchanged.

## Validation

- `npm pkg get name homepage bugs repository --silent`
- `npm pack --dry-run --ignore-scripts --json --silent`
- `git diff --check`
